### PR TITLE
Feat: method `url`

### DIFF
--- a/src/Responder.php
+++ b/src/Responder.php
@@ -123,4 +123,14 @@ final class Responder
 
         return $response;
     }
+
+     /**
+      * Returns the generated Url for the given route and parameters (absolute URL by default).
+      *
+     * @param array<array-key, scalar> $parameters
+     */
+    public function url(string $route, array $parameters = [], int $referenceType = UrlGeneratorInterface::ABSOLUTE_URL): string
+    {
+        return $this->urlGenerator->generate($route, $parameters, $referenceType);
+    }
 }

--- a/tests/ResponderTest.php
+++ b/tests/ResponderTest.php
@@ -161,4 +161,26 @@ final class ResponderTest extends TestCase
 
         self::assertSame('inline; filename=invoice.pdf', $response->headers->get('Content-Disposition'));
     }
+
+    public function testUrl(): void
+    {
+        $this->urlGenerator
+            ->expects(self::once())
+            ->method('generate')
+            ->with('foo_bar', ['foo' => 'bar'], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.com/bar/foo');
+
+        self::assertSame('https://example.com/bar/foo', $this->responder->url('foo_bar', ['foo' => 'bar']));
+    }
+
+    public function testRootRelativeUrl(): void
+    {
+        $this->urlGenerator
+            ->expects(self::once())
+            ->method('generate')
+            ->with('foo_bar', ['foo' => 'bar'], UrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/bar/foo');
+
+        self::assertSame('/bar/foo', $this->responder->url('foo_bar', ['foo' => 'bar'], UrlGeneratorInterface::ABSOLUTE_PATH));
+    }
 }


### PR DESCRIPTION
I really often need generated URL in my controllers
 * often absolute (headers, soft redirects, debug headers)
 * sometimes root-relative (check canonical path)