### PR TITLE
Require safe `twig/twig` versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/http-foundation": "^6.4.14 || ^7.1.7",
         "symfony/routing": "^6.3 || ^7.0",
         "symfony/serializer": "^6.3 || ^7.0",
-        "twig/twig": "^2.13 || ^3.0"
+        "twig/twig": "^2.16.1 || ^3.14"
     },
     "require-dev": {
         "ergebnis/php-cs-fixer-config": "^5.0",


### PR DESCRIPTION
See
* https://symfony.com/blog/twig-security-release-possible-sandbox-bypass
