### PR TITLE
Add Rector with fluent config builder

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,27 @@ jobs:
             - name: "Run friendsofphp/php-cs-fixer"
               run: "vendor/bin/php-cs-fixer fix --diff --verbose"
 
+    rector:
+        name: "Rector"
+
+        runs-on: "ubuntu-latest"
+
+        steps:
+            - name: "Checkout"
+              uses: "actions/checkout@v6"
+
+            - name: "Install PHP with extensions"
+              uses: "shivammathur/setup-php@v2"
+              with:
+                  coverage: "none"
+                  php-version: "8.2"
+
+            - name: "Install dependencies with composer"
+              uses: "ramsey/composer-install@v3"
+
+            - name: "Run rector/rector"
+              run: "vendor/bin/rector --dry-run"
+
     phpstan:
         name: PHPStan
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor/
 composer.lock
+.build/
 .phpunit.cache
 .phpunit.result.cache
 .php-cs-fixer.cache

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ phpstan: vendor
 cs: vendor
 	php vendor/bin/php-cs-fixer fix --diff --verbose
 
+.PHONY: rector
+rector: vendor
+	symfony php vendor/bin/rector
+
 .PHONY: test
 test: vendor
 	php vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "ergebnis/php-cs-fixer-config": "^6.0",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^10.5",
+        "rector/rector": "^2.3",
         "symfony/psr-http-message-bridge": "^2.1"
     },
     "suggest": {

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Attribute\SortAttributeNamedArgsRector;
+use Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector;
+use Rector\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector;
+use Rector\CodeQuality\Rector\FuncCall\SortCallLikeNamedArgsRector;
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
+use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
+use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
+use Rector\ValueObject\PhpVersion;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__.'/rector.php',
+        __DIR__.'/src',
+        __DIR__.'/tests',
+    ])
+    ->withCache('.build/rector')
+    ->withPhpVersion(PhpVersion::PHP_82)
+    ->withImportNames(importShortClasses: false)
+    ->withParallel()
+    ->withPhpSets()
+    ->withComposerBased(phpunit: true)
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        earlyReturn: true,
+        phpunitCodeQuality: true,
+    )
+    ->withSkip([
+        SortAttributeNamedArgsRector::class,
+        SortCallLikeNamedArgsRector::class,
+        SimplifyRegexPatternRector::class, // Keep explicit regex patterns for better readability
+        RemoveUnusedPublicMethodParameterRector::class => [
+            __DIR__.'/src/EventListener', // Keep event args in listeners for consistency
+        ],
+        RemoveNullArgOnNullDefaultParamRector::class => [
+            __DIR__.'/tests', // Keep explicit null arguments in tests for clarity
+        ],
+        LocallyCalledStaticMethodToNonStaticRector::class,
+        PreferPHPUnitThisCallRector::class,
+        NullToStrictStringFuncCallArgRector::class, // Avoid redundant casts when value is already a string
+    ]);

--- a/src/Psr7Responder.php
+++ b/src/Psr7Responder.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Twig\Error\Error as TwigError;
 
-final class Psr7Responder
+final readonly class Psr7Responder
 {
     public function __construct(
         private Responder $responder,

--- a/src/Responder.php
+++ b/src/Responder.php
@@ -24,7 +24,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Twig\Environment;
 use Twig\Error\Error as TwigError;
 
-final class Responder
+final readonly class Responder
 {
     public function __construct(
         private Environment $twig,

--- a/tests/Psr7ResponderTest.php
+++ b/tests/Psr7ResponderTest.php
@@ -31,21 +31,18 @@ use Twig\Environment;
 
 final class Psr7ResponderTest extends TestCase
 {
-    private MockObject $twig;
     private MockObject $serializer;
     private MockObject $urlGenerator;
     private MockObject $psrHttpFactory;
-    private Responder $responder;
     private Psr7Responder $psr7Responder;
 
     protected function setUp(): void
     {
-        $this->twig = $this->createMock(Environment::class);
         $this->serializer = $this->createMock(SerializerInterface::class);
         $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $this->psrHttpFactory = $this->createMock(PsrHttpFactory::class);
-        $this->responder = new Responder($this->twig, $this->urlGenerator, $this->serializer);
-        $this->psr7Responder = new Psr7Responder($this->responder, $this->psrHttpFactory);
+        $responder = new Responder($this->createMock(Environment::class), $this->urlGenerator, $this->serializer);
+        $this->psr7Responder = new Psr7Responder($responder, $this->psrHttpFactory);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- Add `rector/rector` as a dev dependency
- Create `rector.php` using the new fluent `RectorConfig::configure()` builder
- Add `.build/` to `.gitignore` for Rector cache
- Add `make rector` target to Makefile
- Add Rector job to CI workflow
- Apply Rector fixes: make `Responder` and `Psr7Responder` `readonly`, clean up unused test properties

## Test plan
- [x] `php vendor/bin/rector --dry-run` passes
- [x] All 18 tests pass
- [x] PHPStan passes at max level
- [x] PHP-CS-Fixer passes
- [ ] CI pipeline passes